### PR TITLE
Configuration entry point

### DIFF
--- a/examples/2D/example_BSD68.ipynb
+++ b/examples/2D/example_BSD68.ipynb
@@ -98,7 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "engine = Engine(\"n2v_2D_BSD.yml\")"
+    "engine = Engine(config_path=\"n2v_2D_BSD.yml\")"
    ]
   },
   {

--- a/examples/2D/example_SEM.ipynb
+++ b/examples/2D/example_SEM.ipynb
@@ -111,7 +111,7 @@
    "source": [
     "# TODO add an option to write to config file ?\n",
     "\n",
-    "engine = Engine(\"n2v_2D_SEM.yml\")"
+    "engine = Engine(config_path=\"n2v_2D_SEM.yml\")"
    ]
   },
   {

--- a/examples/3D/example_flywing_3D.ipynb
+++ b/examples/3D/example_flywing_3D.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "engine = Engine(\"n2v_3D.yml\")"
+    "engine = Engine(config_path=\"n2v_3D.yml\")"
    ]
   },
   {
@@ -187,7 +187,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.8.17"
   },
   "vscode": {
    "interpreter": {

--- a/examples/3D/n2v_3D.yml
+++ b/examples/3D/n2v_3D.yml
@@ -4,10 +4,6 @@ experiment_name: N2V_BSD_test_3d1
 # Working directory (logs, models, etc), its parent folder must exist
 working_directory: n2v_bsd_test
 
-# Optional
-# Absolute or relative (wrt working_directory) path to model
-trained_model: N2V_BSD_test_3d1_best.pth
-
 algorithm:
   # Loss, currently only n2v is supported
   loss: n2v
@@ -73,7 +69,7 @@ training:
 
   # Optional, automatic mixed precision
   amp:
-  #   # Use (True or False)
+    #   # Use (True or False)
     use: True
 
   #   # Optional, scaling parameter for mixed precision training, power of 2 recommended.
@@ -88,9 +84,9 @@ data:
   axes: ZYX
 
   # Optional, path to the data, absolute or relative to working_directory
-  training_path: /home/igor.zubarev/projects/caremics/examples/data/flywing-data
-  validation_path: /home/igor.zubarev/projects/caremics/examples/data/flywing-data
-  prediction_path: /home/igor.zubarev/projects/caremics/examples/data/flywing-data
+  training_path: data/denoising-Flywing.unzip
+  validation_path: data/denoising-Flywing.unzip
+  prediction_path: data/denoising-Flywing.unzip
 
   # Optional, mean/std of the dataset
   # mean = Null

--- a/src/careamics_restoration/engine.py
+++ b/src/careamics_restoration/engine.py
@@ -91,14 +91,25 @@ class Engine:
 
         if self.use_wandb:
             try:
+                from wandb.errors import UsageError
+
                 from careamics_restoration.utils.wandb import WandBLogging
 
-                self.wandb = WandBLogging(
-                    experiment_name=self.cfg.experiment_name,
-                    log_path=self.cfg.working_directory,
-                    config=self.cfg,
-                    model_to_watch=self.model,
-                )
+                try:
+                    self.wandb = WandBLogging(
+                        experiment_name=self.cfg.experiment_name,
+                        log_path=self.cfg.working_directory,
+                        config=self.cfg,
+                        model_to_watch=self.model,
+                    )
+                except UsageError as e:
+                    self.logger.warning(
+                        f"Wandb usage error, using default logger. Check whether wandb "
+                        f"correctly configured:\n"
+                        f"{e}"
+                    )
+                    self.use_wandb = False
+
             except ModuleNotFoundError:
                 self.logger.warning(
                     "Wandb not installed, using default logger. Try pip install wandb"

--- a/src/careamics_restoration/engine.py
+++ b/src/careamics_restoration/engine.py
@@ -67,7 +67,7 @@ class Engine:
     ) -> None:
         # Sanity checks
         if config is None and config_path is None:
-            raise ValueError("No configuration or model path provided.")
+            raise ValueError("No configuration or path provided.")
 
         if config is not None:
             self.cfg = config

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -64,6 +64,7 @@ def base_configuration(
             extraction_strategy="random",
             augmentation=True,
             num_workers=0,
+            use_wandb=False,
         ),
         prediction=Prediction(use_tiling=False),
     )
@@ -83,10 +84,7 @@ def test_is_engine_runnable(base_configuration: Configuration):
     """
     Test if basic workflow does not fail - train model and then predict
     """
-    # TODO: remove when engine accepts configuration in init
-    config_path = dump_config(base_configuration)
-
-    engine = Engine(config_path)
+    engine = Engine(config=base_configuration)
     engine.train()
 
     model_name = f"{engine.cfg.experiment_name}_best.pth"


### PR DESCRIPTION
- Add `Configuration` as a possible entry point to the `Engine`
- Fix the notebooks `Engine` call
- Adapted smoke test
- Smoke test doesn't use wandb anymore
- Added an elegant failure for wandb UserError (ran into this because I don't have a wandb key)

⚠️ Calling the `Engine` now requires specifying the parameter!

E.g.:
```python
engine = Engine(config_path="path/to/config")
engine = Engine(config=Configuration(...))
```