### PR TITLE
Remove paths from configuration

### DIFF
--- a/examples/2D/example_BSD68.ipynb
+++ b/examples/2D/example_BSD68.ipynb
@@ -124,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "torchsummary.summary(engine.model.cuda(), (1, 64, 64))"
+    "torchsummary.summary(engine.model, (1, 64, 64))"
    ]
   },
   {
@@ -133,7 +133,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "engine.train()"
+    "engine.train(train_path=Path(files[0]).parent, val_path=Path(files[1]).parent)"
    ]
   },
   {

--- a/examples/2D/example_SEM.ipynb
+++ b/examples/2D/example_SEM.ipynb
@@ -99,8 +99,8 @@
     "train_path.mkdir(parents=True, exist_ok=True)\n",
     "val_path.mkdir(parents=True, exist_ok=True)\n",
     "\n",
-    "shutil.move(root_path / files[0], train_path / \"train_image.tif\")\n",
-    "shutil.move(root_path / files[1], val_path / \"val_image.tif\")"
+    "shutil.copy(root_path / files[0], train_path / \"train_image.tif\")\n",
+    "shutil.copy(root_path / files[1], val_path / \"val_image.tif\")"
    ]
   },
   {
@@ -109,8 +109,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO add an option to write to config file ?\n",
-    "\n",
     "engine = Engine(config_path=\"n2v_2D_SEM.yml\")"
    ]
   },
@@ -120,7 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "engine.train()"
+    "engine.train(train_path=train_path, val_path=val_path)"
    ]
   },
   {

--- a/examples/2D/example_SEM.ipynb
+++ b/examples/2D/example_SEM.ipynb
@@ -127,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "preds = engine.predict()"
+    "preds = engine.predict(pred_path=train_path)"
    ]
   },
   {

--- a/examples/2D/n2v_2D_BSD.yml
+++ b/examples/2D/n2v_2D_BSD.yml
@@ -6,7 +6,7 @@ working_directory: n2v_bsd_test
 
 # Optional
 # Absolute or relative (wrt working_directory) path to model
-# trained_model: 
+# trained_model:
 
 algorithm:
   # Loss, currently only n2v is supported
@@ -73,7 +73,7 @@ training:
 
   # Optional, automatic mixed precision
   amp:
-  #   # Use (True or False)
+    #   # Use (True or False)
     use: True
 
   #   # Optional, scaling parameter for mixed precision training, power of 2 recommended.
@@ -86,11 +86,6 @@ data:
 
   # Axes, among STCZYX with constraints on order
   axes: SYX
-
-  # Optional, path to the data, absolute or relative to working_directory
-  training_path: ../data/BSD68_reproducibility/BSD68_reproducibility_data/train
-  validation_path: ../data/BSD68_reproducibility/BSD68_reproducibility_data/val
-  prediction_path: ../data/BSD68_reproducibility/BSD68_reproducibility_data/test
 
   # Optional, mean/std of the dataset
   # mean = Null

--- a/examples/2D/n2v_2D_SEM.yml
+++ b/examples/2D/n2v_2D_SEM.yml
@@ -66,7 +66,7 @@ training:
   augmentation: True
 
   # Optional, use WandB (True or False), must be installed in your conda environment
-  # use_wandb: True
+  use_wandb: False
 
   # Optional, number of workers for data loading, greater or equal than 0
   num_workers: 0
@@ -86,11 +86,6 @@ data:
 
   # Axes, among STCZYX with constraints on order
   axes: YX
-
-  # Optional, path to the data, absolute or relative to working_directory
-  training_path: data/n2v_sem/train
-  validation_path: data/n2v_sem/val
-  prediction_path: data/n2v_sem/train
 
 # Optional
 prediction:

--- a/examples/3D/example_flywing_3D.ipynb
+++ b/examples/3D/example_flywing_3D.ipynb
@@ -74,11 +74,10 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Visualize tiles ? Model summary ?"
+    "Visualize model"
    ]
   },
   {
@@ -87,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "torchsummary.summary(engine.model.cuda(), (1, 32, 64, 64))"
+    "torchsummary.summary(engine.model, (1, 32, 64, 64))"
    ]
   },
   {
@@ -105,7 +104,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "engine.train()"
+    "path_to_data = Path(files[0]).parent\n",
+    "engine.train(train_path=path_to_data, val_path=path_to_data)"
    ]
   },
   {

--- a/examples/3D/example_flywing_3D.ipynb
+++ b/examples/3D/example_flywing_3D.ipynb
@@ -122,7 +122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "preds = engine.predict()"
+    "preds = engine.predict(pred_path=path_to_data)"
    ]
   },
   {

--- a/examples/3D/n2v_3D.yml
+++ b/examples/3D/n2v_3D.yml
@@ -62,7 +62,7 @@ training:
   augmentation: True
 
   # Optional, use WandB (True or False), must be installed in your conda environment
-  # use_wandb: True
+  use_wandb: False
 
   # Optional, number of workers for data loading, greater or equal than 0
   num_workers: 0
@@ -82,11 +82,6 @@ data:
 
   # Axes, among STCZYX with constraints on order
   axes: ZYX
-
-  # Optional, path to the data, absolute or relative to working_directory
-  training_path: data/denoising-Flywing.unzip
-  validation_path: data/denoising-Flywing.unzip
-  prediction_path: data/denoising-Flywing.unzip
 
   # Optional, mean/std of the dataset
   # mean = Null

--- a/src/careamics_restoration/config/data.py
+++ b/src/careamics_restoration/config/data.py
@@ -24,6 +24,7 @@ class SupportedExtensions(str, Enum):
 
     TIFF = "tiff"
     TIF = "tif"
+    NPY = "npy"
 
     @classmethod
     def _missing_(cls, value: object):

--- a/src/careamics_restoration/config/training.py
+++ b/src/careamics_restoration/config/training.py
@@ -348,7 +348,7 @@ class Training(BaseModel):
     augmentation: bool
 
     # Optional fields
-    use_wandb: bool = True
+    use_wandb: bool = False
     num_workers: int = Field(default=0, ge=0)
     amp: AMP = AMP()
 
@@ -406,7 +406,7 @@ class Training(BaseModel):
         if exclude_optionals:
             # remove optional arguments if they are default
             defaults = {
-                "use_wandb": True,
+                "use_wandb": False,
                 "num_workers": 0,
                 "amp": AMP().model_dump(),
             }

--- a/src/careamics_restoration/dataset/tiff_dataset.py
+++ b/src/careamics_restoration/dataset/tiff_dataset.py
@@ -67,6 +67,10 @@ class TiffDataset(torch.utils.data.IterableDataset):
         patch_transform: Optional[Callable] = None,
         patch_transform_params: Optional[Dict] = None,
     ) -> None:
+        self.data_path = Path(data_path)
+        if not self.data_path.is_dir():
+            raise ValueError("Path to data should be an existing folder.")
+
         self.data_path = data_path
         self.data_format = data_format
         self.axes = axes
@@ -98,27 +102,6 @@ class TiffDataset(torch.utils.data.IterableDataset):
         return files
 
     def read_image(self, file_path: Path) -> np.ndarray:
-        """_summary_.
-
-        Parameters
-        ----------
-        file_path : Path
-            _description_
-
-        Returns
-        -------
-        np.ndarray
-            _description_
-
-        Raises
-        ------
-        e
-            _description_
-        ValueError
-            _description_
-        ValueError
-            _description_
-        """
         if file_path.suffix == ".npy":
             try:
                 sample = np.load(file_path)

--- a/src/careamics_restoration/dataset/tiff_dataset.py
+++ b/src/careamics_restoration/dataset/tiff_dataset.py
@@ -260,7 +260,9 @@ class TiffDataset(torch.utils.data.IterableDataset):
                     yield item
 
 
-def get_train_dataset(config: Configuration) -> TiffDataset:
+def get_train_dataset(
+    config: Configuration, train_path: Union[str, Path]
+) -> TiffDataset:
     """
     Create TiffDataset instance from configuration.
 
@@ -271,10 +273,8 @@ def get_train_dataset(config: Configuration) -> TiffDataset:
     if config.training is None:
         raise ValueError("Training configuration is not defined.")
 
-    data_path = config.data.training_path
-
     dataset = TiffDataset(
-        data_path=data_path,
+        data_path=train_path,
         data_format=config.data.data_format,
         axes=config.data.axes,
         mean=config.data.mean,
@@ -289,11 +289,13 @@ def get_train_dataset(config: Configuration) -> TiffDataset:
     return dataset
 
 
-def get_validation_dataset(config: Configuration) -> TiffDataset:
+def get_validation_dataset(
+    config: Configuration, val_path: Union[str, Path]
+) -> TiffDataset:
     if config.training is None:
         raise ValueError("Training configuration is not defined.")
 
-    data_path = config.data.validation_path
+    data_path = val_path
 
     dataset = TiffDataset(
         data_path=data_path,

--- a/src/careamics_restoration/dataset/tiff_dataset.py
+++ b/src/careamics_restoration/dataset/tiff_dataset.py
@@ -297,7 +297,9 @@ def get_validation_dataset(
     return dataset
 
 
-def get_prediction_dataset(config: Configuration) -> TiffDataset:
+def get_prediction_dataset(
+    config: Configuration, pred_path: Union[str, Path]
+) -> TiffDataset:
     if config.prediction is None:
         raise ValueError("Prediction configuration is not defined.")
 
@@ -307,7 +309,7 @@ def get_prediction_dataset(config: Configuration) -> TiffDataset:
         patch_extraction_method = None
 
     dataset = TiffDataset(
-        data_path=config.data.prediction_path,
+        data_path=pred_path,
         data_format=config.data.data_format,
         axes=config.data.axes,
         mean=config.data.mean,

--- a/src/careamics_restoration/engine.py
+++ b/src/careamics_restoration/engine.py
@@ -332,7 +332,7 @@ class Engine:
         # set model to eval mode
         self.model.to(self.device)
         self.model.eval()
-        
+
         # Reset progress bar
         self.progress.reset()
 

--- a/src/careamics_restoration/engine.py
+++ b/src/careamics_restoration/engine.py
@@ -512,6 +512,8 @@ class Engine:
         return self.cfg.working_directory.absolute() / name
 
     def __del__(self) -> None:
+        del self.progress
+
         if hasattr(self, "logger"):
             for handler in self.logger.handlers:
                 if isinstance(handler, FileHandler):

--- a/src/careamics_restoration/utils/__init__.py
+++ b/src/careamics_restoration/utils/__init__.py
@@ -1,3 +1,3 @@
 from .normalization import denormalize, normalize
 from .torch_utils import get_device, setup_cudnn_reproducibility
-from .validators import check_axes_validity
+from .validators import check_array_validity, check_axes_validity

--- a/src/careamics_restoration/utils/logging.py
+++ b/src/careamics_restoration/utils/logging.py
@@ -127,6 +127,9 @@ class ProgressLogger:
 
         return task_id
 
+    def __del__(self):
+        self.reset()
+
     def reset(self) -> None:
         """Exits the logger."""
         if self.live is not None:

--- a/src/careamics_restoration/utils/logging.py
+++ b/src/careamics_restoration/utils/logging.py
@@ -127,6 +127,9 @@ class ProgressLogger:
 
         return task_id
 
+    def __del__(self):
+        self.exit()
+
     def exit(self) -> None:
         """Exits the logger."""
         self.live.__exit__(None, None, None)

--- a/src/careamics_restoration/utils/validators.py
+++ b/src/careamics_restoration/utils/validators.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 AXES = "STCZYX"
 
 
@@ -69,3 +71,20 @@ def check_axes_validity(axes: str) -> bool:
                 )
 
     return True
+
+
+def check_array_validity(array: np.ndarray, axes: str):
+    """Check that the numpy array is compatible with the axes.
+
+    Parameters
+    ----------
+    array : np.ndarray
+        Numpy array
+    axes : str
+        Valid axes (see check_axes_validity)
+    """
+    # TODO discuss that one
+    if len(array.shape) - 2 != len(axes):
+        raise ValueError(
+            f"Array has {len(array.shape)} dimensions, but axes are {len(axes)}."
+        )

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -138,12 +138,6 @@ def test_at_least_one_of_training_or_prediction(complete_config: dict):
     config_train = Configuration(**test_config)
     assert config_train.training.model_dump() == test_config["training"]
 
-    # test that config fails if training+validation data is not there
-    test_config["data"].pop("training_path")
-    test_config["data"].pop("validation_path")
-    with pytest.raises(ValueError):
-        Configuration(**test_config)
-
     # remove training
     test_config.pop("training")
 
@@ -151,13 +145,6 @@ def test_at_least_one_of_training_or_prediction(complete_config: dict):
     test_config["prediction"] = copy.deepcopy(complete_config["prediction"])
     config_pred = Configuration(**test_config)
     assert config_pred.prediction.model_dump() == test_config["prediction"]
-
-    # test that config fails if prediction data is not there
-    # we must add the training path so that Data model gets validated
-    test_config["data"] = copy.deepcopy(complete_config["data"])
-    test_config["data"].pop("prediction_path")
-    with pytest.raises(ValueError):
-        Configuration(**test_config)
 
 
 def test_wrong_values_by_assignment(complete_config: dict):
@@ -219,7 +206,7 @@ def test_minimum_config(minimum_config: dict):
 def test_complete_config(complete_config: dict):
     """Test that we can instantiate a minimum config."""
     dictionary = Configuration(**complete_config).model_dump()
-    assert sorted(dictionary) == sorted(complete_config)
+    assert dictionary == complete_config
 
 
 def test_config_to_dict_with_default_optionals(complete_config: dict):
@@ -248,8 +235,7 @@ def test_config_to_dict_with_default_optionals(complete_config: dict):
 
     # instantiate config
     myconf = Configuration(**complete_config)
-    # TODO check better way to compare dictionaries
-    assert sorted(myconf.model_dump(exclude_optionals=False)) == sorted(complete_config)
+    assert myconf.model_dump(exclude_optionals=False) == complete_config
 
 
 def test_config_to_yaml(tmp_path: Path, minimum_config: dict):

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -51,44 +51,6 @@ def test_config_invalid_working_directory(tmp_path: Path, minimum_config: dict):
         Configuration(**minimum_config)
 
 
-@pytest.mark.parametrize("model_path", ["model.pth"])
-def test_config_valid_model(tmp_path: Path, complete_config: dict, model_path: str):
-    """Test valid model path."""
-    path = tmp_path / model_path
-    path.parent.mkdir(exist_ok=True, parents=True)
-    path.touch()
-
-    complete_config["working_directory"] = tmp_path
-    complete_config["trained_model"] = model_path
-
-    myconf = Configuration(**complete_config)
-    assert myconf.trained_model == tmp_path / model_path
-
-
-def test_config_valid_model_absolute(tmp_path: Path, complete_config: dict):
-    """Test valid model path."""
-    path = tmp_path / "tmp1/tmp2/model.pth"
-    path.parent.mkdir(exist_ok=True, parents=True)
-    path.touch()
-
-    complete_config["working_directory"] = tmp_path
-    complete_config["trained_model"] = str(path.absolute())
-
-    myconf = Configuration(**complete_config)
-    assert str(myconf.trained_model) == complete_config["trained_model"]
-
-
-@pytest.mark.parametrize("model_path", ["model", "tmp/model"])
-def test_config_invalid_model_path(
-    tmp_path: Path, complete_config: dict, model_path: str
-):
-    """Test that invalid model path raise an error."""
-    complete_config["working_directory"] = tmp_path
-    complete_config["trained_model"] = model_path
-    with pytest.raises(ValueError):
-        Configuration(**complete_config)
-
-
 def test_3D_algorithm_and_data_compatibility(minimum_config: dict):
     """Test that errors are raised if algithm `is_3D` and data axes are incompatible."""
     # 3D but no Z in axes
@@ -160,11 +122,6 @@ def test_wrong_values_by_assignment(complete_config: dict):
     config.working_directory = complete_config["working_directory"]
     with pytest.raises(ValueError):
         config.working_directory = "o/o"
-
-    # trained model
-    config.trained_model = complete_config["trained_model"]
-    with pytest.raises(ValueError):
-        config.trained_model = [None]
 
     # data
     config.data = complete_config["data"]

--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -1,11 +1,9 @@
-from pathlib import Path
-
 import pytest
 
 from careamics_restoration.config.data import Data, SupportedExtensions
 
 
-@pytest.mark.parametrize("ext", ["npy", ".npy", "tiff", "tif", "TIFF", "TIF", ".TIF"])
+@pytest.mark.parametrize("ext", ["tiff", "tif", "TIFF", "TIF", ".TIF"])
 def test_supported_extensions_case_insensitive(ext: str):
     """Test that SupportedExtension enum accepts all extensions in upper
     cases and with ."""
@@ -18,7 +16,7 @@ def test_supported_extensions_case_insensitive(ext: str):
     assert sup_ext.value == new_ext
 
 
-@pytest.mark.parametrize("ext", ["nd2", "jpg", "png ", "zarr"])
+@pytest.mark.parametrize("ext", ["nd2", "jpg", "png ", "npy", "zarr"])
 def test_wrong_extensions(minimum_config: dict, ext: str):
     """Test that supported model raises ValueError for unsupported extensions."""
     data_config = minimum_config["data"]
@@ -27,79 +25,6 @@ def test_wrong_extensions(minimum_config: dict, ext: str):
     # instantiate Data model
     with pytest.raises(ValueError):
         Data(**data_config)
-
-
-@pytest.mark.parametrize("path", ["invalid/path", "training/file_0.tif"])
-def test_invalid_training_path(tmp_path: Path, minimum_config: dict, path: str):
-    """Test that Data model raises ValueError for invalid path."""
-    data_config = minimum_config["data"]
-    data_config["training_path"] = tmp_path / path
-
-    # instantiate Data model
-    with pytest.raises(ValueError):
-        Data(**data_config)
-
-
-def test_wrong_extension(minimum_config: dict):
-    """Test that Data model raises ValueError for incompatible extension
-    and path.
-
-    Note: minimum configuration has data_format tif.
-    """
-    data_config = minimum_config["data"]
-    data_config["data_format"] = "npy"
-
-    # instantiate Data model
-    with pytest.raises(ValueError):
-        Data(**data_config)
-
-
-def test_at_least_one_of_training_or_prediction(complete_config: dict):
-    """Test that Data model raises an error if both training and prediction
-    paths are None (not supplied)."""
-    training = complete_config["data"]["training_path"]
-    validation = complete_config["data"]["validation_path"]
-    prediction = complete_config["data"]["prediction_path"]
-
-    # None specified
-    with pytest.raises(ValueError):
-        Data(data_format="tif", axes="YX")
-
-    # Only prediction specified
-    data_model = Data(data_format="tif", axes="YX", prediction_path=prediction)
-    assert str(data_model.prediction_path) == prediction
-
-    # Only training specified
-    data_model = Data(
-        data_format="tif", axes="YX", training_path=training, validation_path=validation
-    )
-    assert str(data_model.training_path) == training
-
-
-def test_both_training_and_validation(complete_config: dict):
-    """Test that both training and validation paths must be specified together."""
-    training = complete_config["data"]["training_path"]
-    validation = complete_config["data"]["validation_path"]
-    prediction = complete_config["data"]["prediction_path"]
-
-    # None specified
-    data_model = Data(data_format="tif", axes="YX", prediction_path=prediction)
-    assert str(data_model.prediction_path) == prediction
-
-    # Both specified
-    data_model = Data(
-        data_format="tif", axes="YX", training_path=training, validation_path=validation
-    )
-    assert str(data_model.training_path) == training
-    assert str(data_model.validation_path) == validation
-
-    # Only validation specified
-    with pytest.raises(ValueError):
-        Data(data_format="tif", axes="YX", validation_path=validation)
-
-    # Only training specified
-    with pytest.raises(ValueError):
-        Data(data_format="tif", axes="YX", training_path=training)
 
 
 @pytest.mark.parametrize("mean, std", [(0, 124.5), (12.6, 0.1)])
@@ -174,21 +99,6 @@ def test_wrong_values_by_assigment(complete_config: dict):
     with pytest.raises(ValueError):
         data_model.axes = "-YX"
 
-    # training path
-    data_model.training_path = complete_config["data"]["training_path"]
-    with pytest.raises(ValueError):
-        data_model.training_path = "invalid/path"
-
-    # validation path
-    data_model.validation_path = complete_config["data"]["validation_path"]
-    with pytest.raises(ValueError):
-        data_model.validation_path = "invalid/path"
-
-    # prediction path
-    data_model.prediction_path = complete_config["data"]["prediction_path"]
-    with pytest.raises(ValueError):
-        data_model.prediction_path = "invalid/path"
-
     # mean
     data_model.mean = complete_config["data"]["mean"]
     with pytest.raises(ValueError):
@@ -210,9 +120,8 @@ def test_data_to_dict_minimum(minimum_config: dict):
 
     assert "data_format" in data_minimum.keys()
     assert "axes" in data_minimum.keys()
-    assert "training_path" in data_minimum.keys()
-    assert "validation_path" in data_minimum.keys()
-    assert "prediction_path" not in data_minimum.keys()
+    assert "mean" not in data_minimum.keys()
+    assert "std" not in data_minimum.keys()
 
 
 def test_data_to_dict_complete(complete_config: dict):
@@ -222,6 +131,5 @@ def test_data_to_dict_complete(complete_config: dict):
 
     assert "data_format" in data_complete.keys()
     assert "axes" in data_complete.keys()
-    assert "training_path" in data_complete.keys()
-    assert "validation_path" in data_complete.keys()
-    assert "prediction_path" in data_complete.keys()
+    assert "mean" in data_complete.keys()
+    assert "std" in data_complete.keys()

--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -3,7 +3,7 @@ import pytest
 from careamics_restoration.config.data import Data, SupportedExtensions
 
 
-@pytest.mark.parametrize("ext", ["tiff", "tif", "TIFF", "TIF", ".TIF"])
+@pytest.mark.parametrize("ext", ["tiff", "tif", "TIFF", "TIF", ".TIF", "npy", "NPY"])
 def test_supported_extensions_case_insensitive(ext: str):
     """Test that SupportedExtension enum accepts all extensions in upper
     cases and with ."""
@@ -16,7 +16,7 @@ def test_supported_extensions_case_insensitive(ext: str):
     assert sup_ext.value == new_ext
 
 
-@pytest.mark.parametrize("ext", ["nd2", "jpg", "png ", "npy", "zarr"])
+@pytest.mark.parametrize("ext", ["nd2", "jpg", "png ", "zarr"])
 def test_wrong_extensions(minimum_config: dict, ext: str):
     """Test that supported model raises ValueError for unsupported extensions."""
     data_config = minimum_config["data"]

--- a/tests/config/test_training.py
+++ b/tests/config/test_training.py
@@ -449,7 +449,7 @@ def test_training_to_dict_optionals(complete_config: dict):
     train_conf = complete_config["training"]
     train_conf["amp"] = AMP(use=False, init_scale=1024)
     train_conf["num_workers"] = 0
-    train_conf["use_wandb"] = True
+    train_conf["use_wandb"] = False
 
     training_complete = Training(**train_conf).model_dump()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 
+@pytest.fixture
 def create_tiff(path: Path, n_files: int):
     """Create tiff files for testing."""
     if not path.exists():
@@ -30,13 +31,6 @@ def minimum_config(tmp_path: Path) -> dict:
     dict
         A minumum configuration example.
     """
-    # create data in the temporary folder
-    path_train = tmp_path / "training"
-    create_tiff(path_train, n_files=3)
-
-    path_validation = tmp_path / "validation"
-    create_tiff(path_validation, n_files=1)
-
     # create dictionary
     configuration = {
         "experiment_name": "LevitatingFrog",
@@ -58,8 +52,6 @@ def minimum_config(tmp_path: Path) -> dict:
             "augmentation": True,
         },
         "data": {
-            "training_path": str(path_train),
-            "validation_path": str(path_validation),
             "data_format": "tif",
             "axes": "SYX",
         },
@@ -90,10 +82,6 @@ def complete_config(tmp_path: Path, minimum_config: dict) -> dict:
     path_model = tmp_path / model
     path_model.touch()
 
-    # create prediction data
-    path_test = tmp_path / "test"
-    create_tiff(path_test, n_files=2)
-
     # add to configuration
     complete_config = copy.deepcopy(minimum_config)
     complete_config["trained_model"] = model
@@ -118,7 +106,6 @@ def complete_config(tmp_path: Path, minimum_config: dict) -> dict:
         "use": True,
         "init_scale": 512,
     }
-    complete_config["data"]["prediction_path"] = str(path_test)
     complete_config["data"]["mean"] = 666.666
     complete_config["data"]["std"] = 42.420
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,15 +76,8 @@ def complete_config(tmp_path: Path, minimum_config: dict) -> dict:
     dict
         A complete configuration example.
     """
-
-    # create model
-    model = "model.pth"
-    path_model = tmp_path / model
-    path_model.touch()
-
     # add to configuration
     complete_config = copy.deepcopy(minimum_config)
-    complete_config["trained_model"] = model
 
     complete_config["algorithm"]["masking_strategy"] = "median"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,7 @@ def complete_config(tmp_path: Path, minimum_config: dict) -> dict:
     complete_config["training"]["lr_scheduler"]["parameters"] = {
         "patience": 22,
     }
-    complete_config["training"]["use_wandb"] = False
+    complete_config["training"]["use_wandb"] = True
     complete_config["training"]["num_workers"] = 6
     complete_config["training"]["amp"] = {
         "use": True,

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -65,6 +65,21 @@ def base_configuration(temp_dir: Path) -> Configuration:
     return configuration
 
 
+@pytest.fixture
+def trained_model(
+    base_configuration: Configuration, example_data_path: Tuple[Path, Path]
+) -> Path:
+    train_path, val_path = example_data_path
+
+    engine = Engine(config=base_configuration)
+    engine.train(train_path, val_path)
+
+    model_name = f"{engine.cfg.experiment_name}_best.pth"
+    result_model_path = engine.cfg.working_directory / model_name
+
+    return result_model_path
+
+
 def dump_config(configuration: Configuration) -> Path:
     temp_dir = configuration.working_directory
     config_path = temp_dir / "test_config.yml"
@@ -97,3 +112,11 @@ def test_is_engine_runnable(
     test_result = engine.predict(external_input=test_image)
 
     assert test_result is not None
+
+
+def test_load_from_checkpoint(example_data_path: Tuple[Path, Path], trained_model):
+    train_path, val_path = example_data_path
+
+    # Create engine from checkpoint
+    second_engine = Engine(model_path=trained_model)
+    second_engine.train(train_path, val_path)

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -40,10 +40,7 @@ def example_data_path(temp_dir: Path) -> Tuple[Path, Path]:
 
 
 @pytest.fixture
-def base_configuration(
-    temp_dir: Path, example_data_path: Tuple[Path, Path]
-) -> Configuration:
-    train_dir, val_dir = example_data_path
+def base_configuration(temp_dir: Path) -> Configuration:
     configuration = Configuration(
         experiment_name="smoke_test",
         working_directory=temp_dir,
@@ -51,9 +48,6 @@ def base_configuration(
         data=Data(
             data_format="tif",
             axes="YX",
-            training_path=train_dir,
-            validation_path=val_dir,
-            prediction_path=val_dir,
         ),
         training=Training(
             num_epochs=1,
@@ -80,12 +74,16 @@ def dump_config(configuration: Configuration) -> Path:
     return config_path
 
 
-def test_is_engine_runnable(base_configuration: Configuration):
+def test_is_engine_runnable(
+    base_configuration: Configuration, example_data_path: Tuple[Path, Path]
+):
     """
     Test if basic workflow does not fail - train model and then predict
     """
+    train_path, val_path = example_data_path
+
     engine = Engine(config=base_configuration)
-    engine.train()
+    engine.train(train_path, val_path)
 
     model_name = f"{engine.cfg.experiment_name}_best.pth"
     result_model_path = engine.cfg.working_directory / model_name

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -65,21 +65,6 @@ def base_configuration(temp_dir: Path) -> Configuration:
     return configuration
 
 
-@pytest.fixture
-def trained_model(
-    base_configuration: Configuration, example_data_path: Tuple[Path, Path]
-) -> Path:
-    train_path, val_path = example_data_path
-
-    engine = Engine(config=base_configuration)
-    engine.train(train_path, val_path)
-
-    model_name = f"{engine.cfg.experiment_name}_best.pth"
-    result_model_path = engine.cfg.working_directory / model_name
-
-    return result_model_path
-
-
 def dump_config(configuration: Configuration) -> Path:
     temp_dir = configuration.working_directory
     config_path = temp_dir / "test_config.yml"
@@ -113,10 +98,7 @@ def test_is_engine_runnable(
 
     assert test_result is not None
 
-
-def test_load_from_checkpoint(example_data_path: Tuple[Path, Path], trained_model):
-    train_path, val_path = example_data_path
-
     # Create engine from checkpoint
-    second_engine = Engine(model_path=trained_model)
+    del engine
+    second_engine = Engine(model_path=result_model_path)
     second_engine.train(train_path, val_path)

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -94,6 +94,6 @@ def test_is_engine_runnable(
 
     # Predict only accepts 4D input for now
     test_image = test_image[None, None, ...]
-    test_result = engine.predict(external_input=test_image, mean=0.5, std=0.5)
+    test_result = engine.predict(external_input=test_image)
 
     assert test_result is not None


### PR DESCRIPTION
- Paths (train, val, predict) are now passed as parameters to the functions
- No model path in the configuration
- Model path can be used to create an Engine
- Mean/std are taken from configuration only