### PR TITLE
Chore(v0.2): warn users when using batch norm and batch size is amll

### DIFF
--- a/src/careamics/compat/lightning/lightning_module.py
+++ b/src/careamics/compat/lightning/lightning_module.py
@@ -445,7 +445,7 @@ def create_careamics_module(
     algorithm_dict["model"] = model_dict
 
     which_algo = algorithm_dict["algorithm"]
-    if which_algo in UNetBasedAlgorithm.get_compatible_algorithms():
+    if which_algo in ["n2v", "care", "n2n", "pn2v"]:
         algorithm_cfg = algorithm_factory(algorithm_dict)
 
         # if use N2V

--- a/src/careamics/config/algorithms/unet_algorithm_config.py
+++ b/src/careamics/config/algorithms/unet_algorithm_config.py
@@ -89,14 +89,12 @@ class UNetBasedAlgorithm(BaseModel):
         """
         return self.model.get_num_input_channels()
 
-    # TODO: remove, used in v0.1.0 only
-    @classmethod
-    def get_compatible_algorithms(cls) -> list[str]:
-        """Get the list of compatible algorithms.
+    def uses_batch_norm(self) -> bool:
+        """Return whether the model uses batch normalization.
 
         Returns
         -------
-        list of str
-            List of compatible algorithms.
+        bool
+            Whether the model uses batch normalization.
         """
-        return ["n2v", "care", "n2n", "pn2v"]
+        return self.model.uses_batch_norm()

--- a/src/careamics/config/architectures/unet_config.py
+++ b/src/careamics/config/architectures/unet_config.py
@@ -148,3 +148,14 @@ class UNetConfig(ArchitectureConfig):
             Number of output channels.
         """
         return self.num_classes
+
+    def uses_batch_norm(self) -> bool:
+        """
+        Return whether the model uses batch normalization.
+
+        Returns
+        -------
+        bool
+            Whether the model uses batch normalization.
+        """
+        return self.use_batch_norm

--- a/src/careamics/config/configuration.py
+++ b/src/careamics/config/configuration.py
@@ -216,7 +216,7 @@ class Configuration(BaseModel, Generic[AlgorithmConfig]):
         """
         if (
             self.algorithm_config.model.uses_batch_norm()
-            and self.data_config.batch_size < 32
+            and self.data_config.batch_size < 8
         ):
             warnings.warn(
                 f"Warning: Batch normalization is used with batch size "

--- a/src/careamics/config/configuration.py
+++ b/src/careamics/config/configuration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from pprint import pformat
 from typing import Annotated, Any, Generic, Literal, Self, TypeVar
 
@@ -202,6 +203,30 @@ class Configuration(BaseModel, Generic[AlgorithmConfig]):
             self.algorithm_config.model.get_num_input_channels(),
             self.algorithm_config.model.get_num_output_channels(),
         )
+        return self
+
+    @model_validator(mode="after")
+    def warn_batch_norm(self: Self) -> Self:
+        """Warn if batch normalization is used with small batch size.
+
+        Returns
+        -------
+        Self
+            Validated configuration.
+        """
+        if (
+            self.algorithm_config.model.uses_batch_norm()
+            and self.data_config.batch_size < 32
+        ):
+            warnings.warn(
+                f"Warning: Batch normalization is used with batch size "
+                f"{self.data_config.batch_size}. We advise using a batch size of at"
+                f" least 32 when using batch normalization, as smaller batch sizes "
+                f"may be unreliable. Consider increasing the batch size or disabling "
+                f"batch normalization in the algorithm `model` parameter.",
+                stacklevel=2,
+            )
+
         return self
 
     def __str__(self) -> str:


### PR DESCRIPTION
## Description

Small batch size when using batch norm can be unstable. This PR adds a warning during validation of the configuration.

Closes https://github.com/CAREamics/careamics/issues/488