### PR TITLE
Feat(Next-Gen CAREamics): add PN2V config support

### DIFF
--- a/src/careamics/config/ng_configs/__init__.py
+++ b/src/careamics/config/ng_configs/__init__.py
@@ -1,7 +1,8 @@
 """Definitions of configurations for CAREamics, compatible with the NG dataset."""
 
-__all__ = ["N2VConfiguration", "NGConfiguration"]
+__all__ = ["N2VConfiguration", "NGConfiguration", "PN2VConfiguration"]
 
 
 from .n2v_configuration import N2VConfiguration
 from .ng_configuration import NGConfiguration
+from .pn2v_configuration import PN2VConfiguration

--- a/src/careamics/config/ng_configs/n2v_configuration.py
+++ b/src/careamics/config/ng_configs/n2v_configuration.py
@@ -5,7 +5,7 @@ from typing import Self
 import numpy as np
 from pydantic import model_validator
 
-from careamics.config.algorithms import N2VAlgorithm
+from careamics.config.algorithms import N2VAlgorithm, PN2VAlgorithm
 from careamics.config.data.patching_strategies import WholePatchingConfig
 
 from .ng_configuration import NGConfiguration
@@ -14,7 +14,7 @@ from .ng_configuration import NGConfiguration
 class N2VConfiguration(NGConfiguration):
     """N2V-specific configuration."""
 
-    algorithm_config: N2VAlgorithm
+    algorithm_config: N2VAlgorithm | PN2VAlgorithm
 
     @model_validator(mode="after")
     def validate_n2v_mask_pixel_perc(self: Self) -> Self:

--- a/src/careamics/config/ng_configs/ng_configuration.py
+++ b/src/careamics/config/ng_configs/ng_configuration.py
@@ -13,6 +13,7 @@ from careamics.config.algorithms import (
     CAREAlgorithm,
     N2NAlgorithm,
     N2VAlgorithm,
+    PN2VAlgorithm,
 )
 from careamics.config.data import NGDataConfig
 from careamics.config.ng_configs.ng_training_configuration import (
@@ -23,7 +24,13 @@ from careamics.lightning.dataset_ng.lightning_modules.constraints import (
     get_model_constraints,
 )
 
-AlgorithmConfig = TypeVar("AlgorithmConfig", CAREAlgorithm, N2NAlgorithm, N2VAlgorithm)
+AlgorithmConfig = TypeVar(
+    "AlgorithmConfig",
+    CAREAlgorithm,
+    N2NAlgorithm,
+    N2VAlgorithm,
+    PN2VAlgorithm,
+)
 
 
 class NGConfiguration(BaseModel, Generic[AlgorithmConfig]):
@@ -302,7 +309,8 @@ class NGConfiguration(BaseModel, Generic[AlgorithmConfig]):
         bool
             True if the algorithm is supervised, False otherwise.
         """
-        return self.algorithm_config.is_supervised()
+        # PN2V does not expose `is_supervised()`, but it is unsupervised like N2V.
+        return self.algorithm_config.algorithm not in {"n2v", "pn2v"}
 
     def set_3D(self, is_3D: bool, axes: str, patch_size: list[int]) -> None:
         """

--- a/src/careamics/config/ng_configs/pn2v_configuration.py
+++ b/src/careamics/config/ng_configs/pn2v_configuration.py
@@ -1,0 +1,11 @@
+"""Configuration for PN2V."""
+
+from careamics.config.algorithms import PN2VAlgorithm
+
+from .n2v_configuration import N2VConfiguration
+
+
+class PN2VConfiguration(N2VConfiguration):
+    """PN2V-specific configuration with N2V-style mask validation."""
+
+    algorithm_config: PN2VAlgorithm

--- a/src/careamics/config/ng_factories/algorithm_factory.py
+++ b/src/careamics/config/ng_factories/algorithm_factory.py
@@ -8,7 +8,7 @@ from careamics.config.algorithms import (
     CAREAlgorithm,
     N2NAlgorithm,
     N2VAlgorithm,
-    # PN2VAlgorithm,  # TODO not yet compatible with NG Dataset
+    PN2VAlgorithm,
 )
 from careamics.config.architectures import UNetConfig
 from careamics.config.support.supported_architectures import SupportedArchitecture
@@ -17,7 +17,7 @@ from careamics.config.support.supported_architectures import SupportedArchitectu
 # TODO rename so that it does not bear the same name as the module?
 def algorithm_factory(
     algorithm: dict[str, Any],
-) -> Union[N2VAlgorithm, N2NAlgorithm, CAREAlgorithm]:
+) -> Union[N2VAlgorithm, N2NAlgorithm, CAREAlgorithm, PN2VAlgorithm]:
     """
     Create an algorithm model for training CAREamics.
 
@@ -28,12 +28,12 @@ def algorithm_factory(
 
     Returns
     -------
-    N2VAlgorithm or N2NAlgorithm or CAREAlgorithm
+    N2VAlgorithm or N2NAlgorithm or CAREAlgorithm or PN2VAlgorithm
         Algorithm model for training CAREamics.
     """
     adapter: TypeAdapter = TypeAdapter(
         Annotated[
-            Union[N2VAlgorithm, N2NAlgorithm, CAREAlgorithm],
+            Union[N2VAlgorithm, N2NAlgorithm, CAREAlgorithm, PN2VAlgorithm],
             Field(discriminator="algorithm"),
         ]
     )
@@ -42,8 +42,8 @@ def algorithm_factory(
 
 def create_algorithm_configuration(
     dimensions: Literal[2, 3],
-    algorithm: Literal["n2v", "care", "n2n"],
-    loss: Literal["n2v", "mae", "mse"],
+    algorithm: Literal["n2v", "care", "n2n", "pn2v"],
+    loss: Literal["n2v", "mae", "mse", "pn2v"],
     independent_channels: bool,
     n_channels_in: int,
     n_channels_out: int,
@@ -61,9 +61,9 @@ def create_algorithm_configuration(
     ----------
     dimensions : {2, 3}
         Dimension of the model, either 2D or 3D.
-    algorithm : {"n2v", "care", "n2n"}
+    algorithm : {"n2v", "care", "n2n", "pn2v"}
         Algorithm to use.
-    loss : {"n2v", "mae", "mse"}
+    loss : {"n2v", "mae", "mse", "pn2v"}
         Loss function to use.
     independent_channels : bool
         Whether to train all channels independently.

--- a/src/careamics/config/ng_factories/ng_config_discriminator.py
+++ b/src/careamics/config/ng_factories/ng_config_discriminator.py
@@ -4,9 +4,14 @@ from typing import Annotated, Any, Union
 
 from pydantic import Discriminator, Tag, TypeAdapter
 
-from careamics.config.algorithms import CAREAlgorithm, N2NAlgorithm, N2VAlgorithm
+from careamics.config.algorithms import (
+    CAREAlgorithm,
+    N2NAlgorithm,
+    N2VAlgorithm,
+    PN2VAlgorithm,
+)
 from careamics.config.data.normalization_config import NormalizationConfig
-from careamics.config.ng_configs import N2VConfiguration
+from careamics.config.ng_configs import N2VConfiguration, PN2VConfiguration
 from careamics.config.ng_configs.ng_configuration import NGConfiguration
 from careamics.config.support import SupportedAlgorithm
 
@@ -57,6 +62,7 @@ def _algo_disciminator(algo: Any) -> SupportedAlgorithm | None:
 NGConfigs = Annotated[
     Union[
         Annotated[N2VConfiguration, Tag(SupportedAlgorithm.N2V)],
+        Annotated[PN2VConfiguration, Tag(SupportedAlgorithm.PN2V)],
         Annotated[NGConfiguration, Tag(SupportedAlgorithm.CARE)],
         Annotated[NGConfiguration, Tag(SupportedAlgorithm.N2N)],
     ],
@@ -66,6 +72,7 @@ NGConfigs = Annotated[
 NGAlgos = Annotated[
     Union[
         Annotated[N2VAlgorithm, Tag(SupportedAlgorithm.N2V)],
+        Annotated[PN2VAlgorithm, Tag(SupportedAlgorithm.PN2V)],
         Annotated[CAREAlgorithm, Tag(SupportedAlgorithm.CARE)],
         Annotated[N2NAlgorithm, Tag(SupportedAlgorithm.N2N)],
     ],

--- a/tests/config/ng_factories/test_algorithm_factory.py
+++ b/tests/config/ng_factories/test_algorithm_factory.py
@@ -1,4 +1,5 @@
 from careamics.config.ng_factories.algorithm_factory import (
+    algorithm_factory,
     create_algorithm_configuration,
 )
 
@@ -41,3 +42,22 @@ class TestUNetConfiguration:
         assert config["model"].in_channels == in_channels
         assert config["model"].num_classes == num_classes
         assert config["model"].independent_channels == independent_channels
+
+
+def test_algorithm_factory_supports_pn2v():
+    """Test that algorithm_factory validates PN2V algorithm dictionaries."""
+    cfg = algorithm_factory(
+        {
+            "algorithm": "pn2v",
+            "loss": "pn2v",
+            "model": {
+                "architecture": "UNet",
+                "conv_dims": 2,
+                "in_channels": 1,
+                "num_classes": 1,
+                "independent_channels": True,
+            },
+            "noise_model": {"model_type": "GaussianMixtureNoiseModel"},
+        }
+    )
+    assert cfg.algorithm == "pn2v"

--- a/tests/unit/config/ng_configs/test_ng_configuration.py
+++ b/tests/unit/config/ng_configs/test_ng_configuration.py
@@ -5,7 +5,11 @@ from contextlib import nullcontext
 
 import pytest
 
-from careamics.config.ng_configs import N2VConfiguration, NGConfiguration
+from careamics.config.ng_configs import (
+    N2VConfiguration,
+    NGConfiguration,
+    PN2VConfiguration,
+)
 from careamics.config.ng_factories.ng_config_discriminator import instantiate_config
 from tests.unit.config.data.test_normalization_config import (
     NORMS_W_NONE,
@@ -40,6 +44,19 @@ def test_unet_configs(algorithm, config_class):
     unet_config_dict = unet_ng_config_dict_testing(algorithm=algorithm)
     cfg = instantiate_config(unet_config_dict)
     assert isinstance(cfg, config_class)
+
+
+def test_pn2v_config_instantiation():
+    """Test that PN2V configuration is discriminated to PN2VConfiguration."""
+    pn2v_config_dict = unet_ng_config_dict_testing(algorithm="n2v")
+    pn2v_config_dict["algorithm_config"]["algorithm"] = "pn2v"
+    pn2v_config_dict["algorithm_config"]["loss"] = "pn2v"
+    pn2v_config_dict["algorithm_config"]["noise_model"] = {
+        "model_type": "GaussianMixtureNoiseModel"
+    }
+
+    cfg = instantiate_config(pn2v_config_dict)
+    assert isinstance(cfg, PN2VConfiguration)
 
 
 # -------------------------- Unit tests ----------------------------


### PR DESCRIPTION
## Summary
- add `PN2VConfiguration` and wire PN2V into NG discriminators/factories so PN2V configs instantiate through shared config entrypoints
- include focused tests for `algorithm_factory` and `instantiate_config` PN2V behavior
- adjust N2V/PN2V typing compatibility in NG config supervision handling

## Test plan
- [x] `uv run pytest tests/config/ng_factories/test_algorithm_factory.py tests/unit/config/ng_configs/test_ng_configuration.py -q`
- [x] pre-commit hooks on commit (`ruff`, `black`, `mypy`, `numpydoc-validation`)

