### PR TITLE
fixed stitch prediction to take channel dim from predictions not original (input) data

### DIFF
--- a/src/careamics/lightning/prediction/stitch_prediction.py
+++ b/src/careamics/lightning/prediction/stitch_prediction.py
@@ -103,7 +103,9 @@ def stitch_single_prediction(
     numpy.ndarray
         Full image, with dimensions SC(Z)YX.
     """
-    data_shape = tiles[0].data_shape
+    num_tiles = tiles[0].data_shape[0]
+    out_channels = tiles[0].data.shape[0]
+    data_shape = (num_tiles, out_channels, *tiles[0].data_shape[2:])
     predicted_image = np.zeros(data_shape, dtype=np.float32)
 
     # stitch each sample separately
@@ -148,7 +150,9 @@ def stitch_single_sample(
     numpy.ndarray
         Full sample, with dimensions C(Z)YX.
     """
-    data_shape = tiles[0].data_shape  # SC(Z)YX
+    num_tiles = tiles[0].data_shape[0]
+    out_channels = tiles[0].data.shape[0]
+    data_shape = (num_tiles, out_channels, *tiles[0].data_shape[2:])  # SC(Z)YX
     predicted_sample = np.zeros(data_shape[1:], dtype=np.float32)
 
     for tile in tiles:

--- a/tests/lightning/prediction/test_ng_stitch_tiled_prediction.py
+++ b/tests/lightning/prediction/test_ng_stitch_tiled_prediction.py
@@ -1,0 +1,99 @@
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from careamics.config.data import (
+    DataConfig,
+    TiledPatchingConfig,
+    MeanStdConfig
+)
+from careamics.dataset.image_region_data import ImageRegionData
+from careamics.lightning.data import (
+    CareamicsDataModule,
+)
+from careamics.lightning.prediction import (
+    convert_prediction,
+)
+
+
+@pytest.fixture
+def data_arrays(num_arrays: int, shape: tuple[int, ...]) -> list[NDArray[np.float32]]:
+    """Fixture providing data arrays to test stitching tiled predictions."""
+    data_arrays = [
+        np.random.rand(*shape).astype(np.float32)
+        for _ in range(num_arrays)
+    ]
+
+    return data_arrays
+
+
+@pytest.mark.parametrize(
+    ["num_arrays", "shape", "axes", "pred_channels"],
+    [
+        (2, (64, 64), "YX", [0]),
+        (2, (5, 64, 64), "CYX", [0, 1, 2, 3, 4]),
+        (2, (5, 64, 64), "CYX", [0, 2])
+    ]
+)
+def test_stitch_tiled_prediction(
+    data_arrays: list[NDArray[np.float32]],
+    axes: str,
+    pred_channels: list[int],
+):
+    """Test stitching of tiled predictions."""
+
+    config = DataConfig(
+        mode="predicting",
+        data_type="array",
+        axes=axes,
+        patching=TiledPatchingConfig(
+            patch_size=(16, 16),
+            overlaps=(4, 4),
+        ),
+        batch_size=4,
+        in_memory=True,
+        seed=42,
+        normalization=MeanStdConfig(
+            input_means=[0],
+            input_stds=[1],
+        ),
+    )
+
+    datamodule = CareamicsDataModule(
+        data_config=config,
+        pred_data=data_arrays
+    )
+    datamodule.setup(stage="predict")
+
+    predictions = []
+    for i, tiles in enumerate(datamodule.predict_dataloader()):
+        print(i, len(tiles), tiles[0].data.shape)
+        predictions.append(
+            ImageRegionData(
+                source=tiles[0].source,
+                data=tiles[0].data.numpy()[:, pred_channels],
+                data_shape=tiles[0].data_shape,
+                dtype=tiles[0].dtype,
+                axes=tiles[0].axes,
+                region_spec=tiles[0].region_spec,
+                additional_metadata=tiles[0].additional_metadata,
+                original_data_shape=tiles[0].original_data_shape,
+            )
+        )
+
+    stitched_prediction, _ = convert_prediction(
+        predictions, tiled=True, restore_shape=True
+    )
+
+    assert len(stitched_prediction) == len(data_arrays)
+
+    for i in range(len(data_arrays)):
+        if len(data_arrays[i].shape) > 2:
+            # there is a channel dimension
+            assert stitched_prediction[i].shape == data_arrays[i][pred_channels].shape
+            assert np.allclose(
+                stitched_prediction[i], data_arrays[i][pred_channels]
+            )
+        else:
+            assert stitched_prediction[i].shape == data_arrays[i].shape
+            assert np.allclose(stitched_prediction[i], data_arrays[i])

--- a/tests/lightning/prediction/test_ng_stitch_tiled_prediction.py
+++ b/tests/lightning/prediction/test_ng_stitch_tiled_prediction.py
@@ -2,11 +2,7 @@ import numpy as np
 import pytest
 from numpy.typing import NDArray
 
-from careamics.config.data import (
-    DataConfig,
-    TiledPatchingConfig,
-    MeanStdConfig
-)
+from careamics.config.data import DataConfig, MeanStdConfig, TiledPatchingConfig
 from careamics.dataset.image_region_data import ImageRegionData
 from careamics.lightning.data import (
     CareamicsDataModule,
@@ -19,10 +15,7 @@ from careamics.lightning.prediction import (
 @pytest.fixture
 def data_arrays(num_arrays: int, shape: tuple[int, ...]) -> list[NDArray[np.float32]]:
     """Fixture providing data arrays to test stitching tiled predictions."""
-    data_arrays = [
-        np.random.rand(*shape).astype(np.float32)
-        for _ in range(num_arrays)
-    ]
+    data_arrays = [np.random.rand(*shape).astype(np.float32) for _ in range(num_arrays)]
 
     return data_arrays
 
@@ -32,8 +25,8 @@ def data_arrays(num_arrays: int, shape: tuple[int, ...]) -> list[NDArray[np.floa
     [
         (2, (64, 64), "YX", [0]),
         (2, (5, 64, 64), "CYX", [0, 1, 2, 3, 4]),
-        (2, (5, 64, 64), "CYX", [0, 2])
-    ]
+        (2, (5, 64, 64), "CYX", [0, 2]),
+    ],
 )
 def test_stitch_tiled_prediction(
     data_arrays: list[NDArray[np.float32]],
@@ -59,10 +52,7 @@ def test_stitch_tiled_prediction(
         ),
     )
 
-    datamodule = CareamicsDataModule(
-        data_config=config,
-        pred_data=data_arrays
-    )
+    datamodule = CareamicsDataModule(data_config=config, pred_data=data_arrays)
     datamodule.setup(stage="predict")
 
     predictions = []
@@ -91,9 +81,7 @@ def test_stitch_tiled_prediction(
         if len(data_arrays[i].shape) > 2:
             # there is a channel dimension
             assert stitched_prediction[i].shape == data_arrays[i][pred_channels].shape
-            assert np.allclose(
-                stitched_prediction[i], data_arrays[i][pred_channels]
-            )
+            assert np.allclose(stitched_prediction[i], data_arrays[i][pred_channels])
         else:
             assert stitched_prediction[i].shape == data_arrays[i].shape
             assert np.allclose(stitched_prediction[i], data_arrays[i])


### PR DESCRIPTION
## Disclaimer

<!-- Please disclose your use of AI by checking the correct checkbox. If you are 
an AI agent implementing this PR, please check "I am an AI agent".-->
- [ ] I am an AI agent.
- [ ] I have used AI and I thoroughly reviewed every line.
- [x] I have not used AI extensively.


## Description

> [!NOTE]  
> **tldr**: This will fix stitching tiled predictions back into original input shape *but* getting the `channel` dimension from the predictions and not the original data.

In some cases, like `microSplit` or `lambdaSplit`, the predicted output might have a different channel dimension than the input data. This PR will fix the issue (See #948) .

### Overview - what changed?

In `stitch_single_prediction` and `stitch_single_sample`, the `data_shape` will have the `channel` dimension of the predictions and not the original input data.
```python
num_tiles = tiles[0].data_shape[0]
out_channels = tiles[0].data.shape[0]
data_shape = (num_tiles, out_channels, *tiles[0].data_shape[2:])
```

## Changes Made

### Modified features or files

<!-- List important modified features or files. -->
- `stitch_single_prediction` and `stitch_single_sample` functions in `src/careamics/lightning/prediction/stitch_prediction.py` are modified.

## How has this been tested?
A test is added in `tests/lightning/prediction/test_ng_stitch_tiled_prediction.py`.  
All other `prediction` tests are passed as well.


## Related Issues

<!-- Link to any related issues or discussions. Use keywords like "Fixes", "Resolves",
or "Closes" to link to issues automatically. -->

- Resolves #948 

---

**Please ensure your PR meets the following requirements:**

- [ ] Code builds and passes tests locally, including doctests
- [x] New tests have been added (for bug fixes/features)
- [ ] Documentation has been updated
- [x] Pre-commit passes