### PR TITLE
Docs: add missing README

### DIFF
--- a/docs/_README.md
+++ b/docs/_README.md
@@ -1,0 +1,35 @@
+# CAREamics guides
+
+These docs are automatically tested in the `.github/workflows/ci_guides.yml` CI and separately imported into the [CAREamics website](https://careamics.github.io/latest/). They consist of a structured organization of python snippets and markdown files.
+
+The structure of the docs on the website is defined in `nav.toml`.
+
+## How to use the snippets
+
+Snippets are stored in python files and automatically aggregated by `test_guides.py` as pytest test cases. A snippet consist of a python code in the following block:
+
+```python
+# %%
+# --8<-- [start:snippet_id]
+...
+# --8<-- [end:snippet_id]
+```
+
+The `snippet_id` is used to identify the snippet and can be used in the markdown files to include the snippet as follows:
+
+````markdown
+```python
+--8<-- "path/to/snippet.py:snippet_id"
+```
+````
+
+> [!NOTE]
+> The path to the snippet is relative to the `docs` folder.
+
+
+## How to add new pages to the guides
+
+The guides are uploaded automatically to the website at build time and organized according to the `nav.toml` file. To add a new page to the guides, simply create a new markdown file in the `docs` folder and add it to the `nav.toml` file.
+
+> [!IMPORTANT]
+> Only existing keys are accepted by the website: Using CAREamics, Tutorials, and Legacy (v0.1). For additional sections, the website's `zensical.toml` file has to be updated.


### PR DESCRIPTION
## Description

In https://github.com/CAREamics/careamics/commit/92304ebae1132dfe620f7cdafc4a8ef2293ab9e4, I renamed the README but forgot to add it back to git. The readme is there to explain how the docs work. However, it cannot be called "README.md" otherwise it takes the place of `index` on the website.

This PR adds it back.

However, I know wonder whether it would not be better to just ignore it when copying in the website at build time.